### PR TITLE
README banner standardization (badges + sections)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # praxis-guard
+
+<!-- plures-readme-banner -->
+[![CI](https://img.shields.io/badge/CI-not_configured-lightgrey.svg)](https://github.com/plures/praxis-guard/actions)\n[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 GitHub App for traceability &amp; decision governance (Praxis Guard)
+
+---
+
+<!-- plures-readme-standard-sections -->
+## Overview\n\n## Install\n\n## Development\n\n## Contributing\n\n## License


### PR DESCRIPTION
This PR applies the Plures README at-a-glance standard:\n\n- Adds a top-of-README banner block (CI badge where available; placeholder where not yet configured)\n- Adds standard section headers to make repos consistent\n\nLocal-first change; non-destructive.\n\nFollow-ups:\n- For repos with placeholder CI badge, add a minimal CI workflow so the badge becomes meaningful.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the repository README formatting and adds placeholder CI badge/standard sections.
> 
> **Overview**
> Standardizes `README.md` by adding a Plures banner block with CI (placeholder) and license badges, plus a horizontal rule.
> 
> Adds a set of standard section headings (`Overview`, `Install`, `Development`, `Contributing`, `License`) to align the repo README with a consistent template.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fa9c4cf93a3e5e6eac9b5ce4b2a060d11b435c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->